### PR TITLE
Update javacc.rb

### DIFF
--- a/javacc.rb
+++ b/javacc.rb
@@ -9,7 +9,7 @@ class Javacc < Formula
   def script target; <<-EOS.undent
     #!/bin/sh
     
-    exec java -cp #{libexec}/javacc-#{version}.jar #{target}
+    exec java -cp #{libexec}/javacc-#{version}.jar #{target} "$@"
     EOS
   end
 


### PR DESCRIPTION
Propagate arguments directed to javacc script to javacc jar.

Presently, calling javacc only ever results in JavaCC help being printed.

This is because the arguments are not propagated towards the invoked .jar file. Using the "$@" token as a parameter pushes forward all arguments given to /usr/local/bin/javacc to the designated .jar file executed within the aforementioned script.